### PR TITLE
Update .gitignore to ignore bin, lib and o directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 x_
 obj
+/bin
+/o
+/lib


### PR DESCRIPTION
I'm not sure if the `x_` and `obj` are used any more, so maybe consider removing them if they're old.