### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 0
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+FixNamespaceComments: false
+IncludeBlocks: Regroup
+IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never
+IncludeCategories:
+  - Regex:           '(^".+"$)'
+    Priority:        1
+  - Regex:           '.*'
+    Priority:        2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Still to be implemented is minor customization around this:
 - It needs to allow customization of compile flags for the project-wide compilation, so that you can disable some warnings.
 - It needs to allow customization of the toolchain, so that you can use it for cross-compiling to other targets, or tune it for some CPU type.
 
-# Developing Evroke
+# Developing Evoke
 
 Everybody is free to help with Evoke development. The simpler things that need to be done are to create issues for things you would like it to do, or for asking help when it does not do what you want it to. You can join the discord at https://includecpp.org . If you want to do more, there are a few open issues already that require a bit more knowledge and time investment, like porting it to run on Windows or OSX.
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,17 @@ Still to be implemented is minor customization around this:
 - It needs to allow customization of compile flags for the project-wide compilation, so that you can disable some warnings.
 - It needs to allow customization of the toolchain, so that you can use it for cross-compiling to other targets, or tune it for some CPU type.
 
-# Helping with Evoke development
+# Developing Evroke
 
 Everybody is free to help with Evoke development. The simpler things that need to be done are to create issues for things you would like it to do, or for asking help when it does not do what you want it to. You can join the discord at https://includecpp.org . If you want to do more, there are a few open issues already that require a bit more knowledge and time investment, like porting it to run on Windows or OSX.
+
+### Clang Format 
+
+Formatting of all source files is done using ClangFormat. Rules for it are specified in .clang-format file in the root of the repository.
+
+**Path:** /.clang-format
+
+**Requires:** [LLVM](http://llvm.org/)
 
 # License
 


### PR DESCRIPTION
I have used the rules that I personally use. Some of it conflicts with what is currently in the repository. I don't care about most of it as long as I don't have to do it manually so whatever you want changed I am ok with it. It is based on rules of current ClangFormat from LLVM 7.0. I use Qt Creator as IDE that supports it as does Visual Studio. Not sure about Visual Studio Code (I use it but not for C++) or other IDEs.