### PR TITLE
For the ubuntu toolset use the config file compile flags.

### DIFF
--- a/toolsets/src/ubuntu.cpp
+++ b/toolsets/src/ubuntu.cpp
@@ -1,9 +1,11 @@
 #include "Component.h"
+#include "Configuration.h"
 #include "File.h"
 #include "PendingCommand.h"
 #include "Project.h"
 #include "Toolset.h"
 #include "dotted.h"
+
 #include <algorithm>
 
 static const std::string compiler = "g++";
@@ -43,7 +45,7 @@ void UbuntuToolset::CreateCommandsFor(Project &project)
                 continue;
             boost::filesystem::path outputFile = std::string("obj") / outputFolder / (f->path.string().substr(component.root.string().size()) + ".o");
             File *of = project.CreateFile(component, outputFile);
-            PendingCommand *pc = new PendingCommand(compiler + " -c -std=c++17 -o " + outputFile.string() + " " + f->path.string() + includes);
+            PendingCommand *pc = new PendingCommand(compiler + " -c " + Configuration::Get().compileFlags + " -o " + outputFile.string() + " " + f->path.string() + includes);
             objects.push_back(of);
             pc->AddOutput(of);
             std::unordered_set<File *> d;


### PR DESCRIPTION
Allows setting global options (-O[0123s]) or whatever global flag is
desired from the config file.

I used the following evoke.conf file to build evoke w/ gcc 6.4 on Debian 9 w/ a custom boost install.  The config file allowed me to redirect it from the the older system boost which does not have the process library, and add the -O3 flag which makes the build match the makefile based build better.

<pre>
# test
compile-flags: -std=c++17 -O3 -pthread -I/opt/boost-1.67.0/include -L/opt/boost-1.67.0/lib
</pre>