### PR TITLE
Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,7 @@ set(INCLUDES  ${CMAKE_CURRENT_SOURCE_DIR}/fw/include
               ${CMAKE_CURRENT_SOURCE_DIR}/toolsets/include 
               ${CMAKE_CURRENT_SOURCE_DIR}/view/include 
               ${CMAKE_CURRENT_SOURCE_DIR}/evoke/include 
-              ${CMAKE_CURRENT_SOURCE_DIR}/reporter/include
-              ${CMAKE_CURRENT_SOURCE_DIR}/boost)
+              ${CMAKE_CURRENT_SOURCE_DIR}/reporter/include)
 
 set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/toolsets/src/known.cpp 
             ${CMAKE_CURRENT_SOURCE_DIR}/toolsets/src/Toolset.cpp 
@@ -45,6 +44,3 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${Boost_LIBRARIES})
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
-
-
-# cmake .. -G "NMake Makefiles" -DCMAKE_TOOLCHAIN_FILE=C:\Users\may64\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x86-windows -DCMAKE_BUILD_TYPE=Release 

--- a/evoke/src/main.cpp
+++ b/evoke/src/main.cpp
@@ -57,7 +57,16 @@ void parseArgs(std::vector<std::string> args, std::map<std::string, std::string 
 
 int main(int argc, const char **argv)
 {
-    std::string toolsetname = "ubuntu";
+    std::string toolsetname;
+
+#if defined(_WIN32)
+    toolsetname = "windows";
+#else
+    toolsetname = "ubuntu";
+#endif
+
+    std::cout << "Building for " << toolsetname << std::endl;
+
     std::string rootpath = filesystem::current_path().generic_string();
     std::string jobcount = std::to_string(std::max(4u, std::thread::hardware_concurrency()));
     std::string reporterName = "guess";

--- a/fw/src/Configuration.cpp
+++ b/fw/src/Configuration.cpp
@@ -9,7 +9,7 @@ void Configuration::LoadDefaults()
 {
 #ifdef _WIN32
     toolchain = "msvc15";
-    compileFlags = "/permissive- -std=c++17";
+    compileFlags = "/permissive- /std:c++latest";
 #elif APPLE
     toolchain = "osx";
     compileFlags = "-std=c++17";

--- a/project/src/Component.cpp
+++ b/project/src/Component.cpp
@@ -21,7 +21,7 @@ Component::Component(const filesystem::path &path, bool isBinary) :
     isBinary(isBinary)
 {
     std::string rp = path.string();
-    if(rp[0] == '.' && rp[1] == '/')
+    if(rp[0] == '.' && (rp[1] == '/' || rp[1] == '\\'))
         rp = rp.substr(2);
     root = rp;
 }

--- a/project/src/Project.cpp
+++ b/project/src/Project.cpp
@@ -82,7 +82,7 @@ void Project::Reload()
 File *Project::CreateFile(Component &c, filesystem::path p)
 {
     std::string subpath = p.string();
-    if(subpath[0] == '.' && subpath[1] == '/')
+    if(subpath[0] == '.' && (subpath[1] == '/' || subpath[1] == '\\'))
         subpath = subpath.substr(2);
     File f(p, c);
     auto f2 = files.emplace(p.string(), std::move(f));
@@ -105,7 +105,13 @@ std::ostream &operator<<(std::ostream &os, const Project &p)
 
 void Project::ReadCode(std::unordered_map<std::string, File> &files, const filesystem::path &path, Component &comp)
 {
+
     File &f = files.emplace(path.generic_string().substr(2), File(path.generic_string().substr(2), comp)).first->second;
+//    File &f = files.emplace(filesystem::absolute(path).generic_string(), File(path.generic_string(), comp)).first->second;
+    std::cout << path.string() << std::endl;
+    std::cout << path << std::endl;
+
+
     comp.files.insert(&f);
 #ifdef _WIN32
     std::string buffer;

--- a/project/src/Project.cpp
+++ b/project/src/Project.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <map>
 
-
 #ifndef _WIN32
 #    include <fcntl.h>
 #    include <sys/mman.h>
@@ -105,13 +104,7 @@ std::ostream &operator<<(std::ostream &os, const Project &p)
 
 void Project::ReadCode(std::unordered_map<std::string, File> &files, const filesystem::path &path, Component &comp)
 {
-
     File &f = files.emplace(path.generic_string().substr(2), File(path.generic_string().substr(2), comp)).first->second;
-//    File &f = files.emplace(filesystem::absolute(path).generic_string(), File(path.generic_string(), comp)).first->second;
-    std::cout << path.string() << std::endl;
-    std::cout << path << std::endl;
-
-
     comp.files.insert(&f);
 #ifdef _WIN32
     std::string buffer;

--- a/project/src/Project.cpp
+++ b/project/src/Project.cpp
@@ -11,10 +11,12 @@
 #include <iostream>
 #include <map>
 
+
 #ifndef _WIN32
 #    include <fcntl.h>
 #    include <sys/mman.h>
 #    include <unistd.h>
+
 #endif
 
 Project::Project(const std::string &rootpath)
@@ -104,6 +106,7 @@ std::ostream &operator<<(std::ostream &os, const Project &p)
 void Project::ReadCode(std::unordered_map<std::string, File> &files, const filesystem::path &path, Component &comp)
 {
     File &f = files.emplace(path.generic_string().substr(2), File(path.generic_string().substr(2), comp)).first->second;
+    comp.files.insert(&f);
 #ifdef _WIN32
     std::string buffer;
     buffer.resize(filesystem::file_size(path));
@@ -112,7 +115,6 @@ void Project::ReadCode(std::unordered_map<std::string, File> &files, const files
     }
     ReadCodeFrom(f, buffer.data(), buffer.size());
 #else
-    comp.files.insert(&f);
     int fd = open(path.c_str(), O_RDONLY);
     size_t fileSize = filesystem::file_size(path);
     void *p = mmap(NULL, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);

--- a/reporter/src/ConsoleReporter.cpp
+++ b/reporter/src/ConsoleReporter.cpp
@@ -1,47 +1,49 @@
-#include "Reporter.h"
 #include "PendingCommand.h"
-#include <string>
+#include "Reporter.h"
+
 #include <cstdio>
 #include <iostream>
-#include <iostream>
+#include <string>
 
 #ifndef _WIN32
-#include <sys/ioctl.h>
-#include <unistd.h>
-#include <signal.h>
+#    include <signal.h>
+#    include <sys/ioctl.h>
+#    include <unistd.h>
 #endif
-
 
 static size_t screenWidth = 80;
 
 #ifndef _WIN32
-void fetchDisplaySize() {
-#ifdef TIOCGSIZE
+void fetchDisplaySize()
+{
+#    ifdef TIOCGSIZE
     struct ttysize ts;
     ioctl(STDIN_FILENO, TIOCGSIZE, &ts);
     screenWidth = ts.ts_cols;
-#elif defined(TIOCGWINSZ)
+#    elif defined(TIOCGWINSZ)
     struct winsize ts;
     ioctl(STDIN_FILENO, TIOCGWINSZ, &ts);
     screenWidth = ts.ws_col;
-#endif /* TIOCGSIZE */
+#    endif /* TIOCGSIZE */
 }
 #endif
 
-ConsoleReporter::ConsoleReporter() {
+ConsoleReporter::ConsoleReporter()
+{
 #ifndef _WIN32
     fetchDisplaySize();
-    signal(SIGWINCH, [](int){ fetchDisplaySize(); });
+    signal(SIGWINCH, [](int) { fetchDisplaySize(); });
 #endif
 }
 
-void ConsoleReporter::Redraw() {
+void ConsoleReporter::Redraw()
+{
     size_t w = screenWidth / activeProcesses.size();
     size_t active = 0;
     for(auto &t : activeProcesses)
         if(t)
             active++;
-    
+
     std::cout << activeProcesses.size() << " concurrent tasks, " << active << " active\n";
     if(w == 0)
     {
@@ -84,21 +86,27 @@ void ConsoleReporter::Redraw() {
     std::cout << "\r\033[1A" << std::flush;
 }
 
-void ConsoleReporter::SetConcurrencyCount(size_t count) {
+void ConsoleReporter::SetConcurrencyCount(size_t count)
+{
     activeProcesses.resize(count);
     Redraw();
 }
 
-void ConsoleReporter::SetRunningCommand(size_t channel, PendingCommand* command) {
+void ConsoleReporter::SetRunningCommand(size_t channel, PendingCommand *command)
+{
     activeProcesses[channel] = command;
     Redraw();
 }
 
-void ConsoleReporter::ReportFailure(PendingCommand* cmd, int err, const std::string& errors) {
+void ConsoleReporter::ReportFailure(PendingCommand *cmd, int err, const std::string &errors)
+{
     // Display error
-    std::cout << "\n\n" << "Error while running: " << cmd->commandToRun;
-    std::cout << "\n\n" << errors << "\n\n";
-    Redraw();
+    if(err)
+    {
+        std::cout << "\n\n"
+                  << "Error while running: " << cmd->commandToRun;
+        std::cout << "\n\n"
+                  << errors << "\n\n";
+        Redraw();
+    }
 }
-
-

--- a/reporter/src/SimpleReporter.cpp
+++ b/reporter/src/SimpleReporter.cpp
@@ -1,19 +1,25 @@
-#include "Reporter.h"
 #include "PendingCommand.h"
+#include "Reporter.h"
+
 #include <iostream>
 
-void SimpleReporter::SetConcurrencyCount(size_t) {
+void SimpleReporter::SetConcurrencyCount(size_t)
+{
 }
 
-void SimpleReporter::SetRunningCommand(size_t, PendingCommand* command) {
-  if (command) 
-    std::cout << command->commandToRun << "\n" << std::flush;
+void SimpleReporter::SetRunningCommand(size_t, PendingCommand *command)
+{
+    if(command)
+        std::cout << command->commandToRun << "\n"
+                  << std::flush;
 }
 
-void SimpleReporter::ReportFailure(PendingCommand* command, int error, const std::string& errors) {
-  if (error) 
-    std::cout << "Error while running " << command->commandToRun << "\n";
-  std::cout << errors << "\n" << std::flush;
+void SimpleReporter::ReportFailure(PendingCommand *command, int error, const std::string &errors)
+{
+    if(error)
+    {
+        std::cout << "Error while running " << command->commandToRun << "\n";
+        std::cout << errors << "\n"
+                  << std::flush;
+    }
 }
-
-

--- a/toolsets/src/Windows.cpp
+++ b/toolsets/src/Windows.cpp
@@ -1,5 +1,16 @@
+#include "Component.h"
+#include "Configuration.h"
+#include "File.h"
+#include "PendingCommand.h"
+#include "Project.h"
 #include "Toolset.h"
+#include "dotted.h"
 
+#include <algorithm>
+#include <stack>
+
+static const std::string compiler = "cl.exe";
+static const std::string archiver = "lib.exe";
 //https://blogs.msdn.microsoft.com/vcblog/2015/12/03/c-modules-in-vs-2015-update-1/
 
 // Enable modules support for MSVC
@@ -8,7 +19,159 @@
 // Tell MSVC to act like a sane compiler (use the latest C++ version in standards conforming mode, use C++ exceptions as specified, and link to the C/C++ runtime)
 //"/std:c++latest /permissive- /EHsc /MD"
 
+static std::string getLibNameFor(Component &component)
+{
+    return "lib" + as_dotted(component.root.string()) + ".lib";
+}
+
+static std::string getExeNameFor(Component &component)
+{
+    if(component.root.string() != ".")
+    {
+        return as_dotted(component.root.string()) + ".exe";
+    }
+    return filesystem::canonical(component.root).filename().string() + ".exe";
+}
+
 void WindowsToolset::CreateCommandsFor(Project &project)
 {
-    std::abort();
+    for(auto &p : project.components)
+    {
+        auto &component = p.second;
+        std::string includes;
+        for(auto &d : getIncludePathsFor(component))
+        {
+            includes += " /I" + d;
+        }
+
+        // TODO: modules: -fmodules-ts --precompile  -fmodules-cache-path=<directory>-fprebuilt-module-path=<directory>
+        filesystem::path outputFolder = component.root;
+        std::vector<File *> objects;
+        for(auto &f : component.files)
+        {
+            if(!project.IsCompilationUnit(f->path.extension().string()))
+                continue;
+            filesystem::path outputFile = std::string("obj") / outputFolder / (f->path.string().substr(component.root.string().size()) + ".obj");
+            File *of = project.CreateFile(component, outputFile);
+            PendingCommand *pc = new PendingCommand(compiler + " /c /EHsc " + Configuration::Get().compileFlags + " /Fo" + filesystem::canonical(outputFile).string() + " " + f->path.string() + includes);
+            objects.push_back(of);
+            pc->AddOutput(of);
+            std::unordered_set<File *> d;
+            std::stack<File *> deps;
+            deps.push(f);
+            size_t index = 0;
+            while(!deps.empty())
+            {
+                File *dep = deps.top();
+                deps.pop();
+                pc->AddInput(dep);
+                for(File *input : dep->dependencies)
+                    if(d.insert(input).second)
+                        deps.push(input);
+                index++;
+            }
+            pc->Check();
+            component.commands.push_back(pc);
+        }
+        if(!objects.empty())
+        {
+            std::string command;
+            filesystem::path outputFile;
+            PendingCommand *pc;
+            if(component.type == "library")
+            {
+                outputFile = "lib/" + getLibNameFor(component);
+                command = archiver + " " + filesystem::canonical(outputFile).string();
+                for(auto &file : objects)
+                {
+                    command += " " + file->path.string();
+                }
+                pc = new PendingCommand(command);
+            }
+            else
+            {
+                outputFile = "bin/" + getExeNameFor(component);
+                command = compiler + " /OUT:" + filesystem::canonical(outputFile).string();
+
+                for(auto &file : objects)
+                {
+                    command += " " + file->path.string();
+                }
+                if(filesystem::exists("lib"))
+                {
+                    command += " /LIBPATH:lib";
+                }
+                std::vector<std::vector<Component *>> linkDeps = GetTransitiveAllDeps(component);
+                std::reverse(linkDeps.begin(), linkDeps.end());
+                for(auto d : linkDeps)
+                {
+                    size_t index = 0;
+                    while(index < d.size())
+                    {
+                        if(d[index]->isHeaderOnly())
+                        {
+                            d[index] = d.back();
+                            d.pop_back();
+                        }
+                        else
+                        {
+                            ++index;
+                        }
+                    }
+                    if(d.empty())
+                        continue;
+                    if(d.size() == 1 || (d.size() == 2 && (d[0] == &component || d[1] == &component)))
+                    {
+                        if(d[0] != &component)
+                        {
+                            command += " " + d[0]->root.string();
+                        }
+                        else if(d.size() == 2)
+                        {
+                            command += " " + d[1]->root.string();
+                        }
+                    }
+                    else
+                    {
+                        for(auto &c : d)
+                        {
+                            if(c != &component)
+                            {
+                                command += " " + c->root.string();
+                            }
+                        }
+                    }
+                }
+                pc = new PendingCommand(command);
+                for(auto &d : linkDeps)
+                {
+                    for(auto &c : d)
+                    {
+                        if(c != &component)
+                        {
+                            pc->AddInput(project.CreateFile(*c, "lib/" + getLibNameFor(*c)));
+                        }
+                    }
+                }
+            }
+            File *libraryFile = project.CreateFile(component, outputFile);
+            pc->AddOutput(libraryFile);
+            for(auto &file : objects)
+            {
+                pc->AddInput(file);
+            }
+            pc->Check();
+            component.commands.push_back(pc);
+            if(component.type == "unittest")
+            {
+                command = outputFile.string();
+                pc = new PendingCommand(command);
+                outputFile += ".log";
+                pc->AddInput(libraryFile);
+                pc->AddOutput(project.CreateFile(component, outputFile.string()));
+                pc->Check();
+                component.commands.push_back(pc);
+            }
+        }
+    }
 }

--- a/toolsets/src/Windows.cpp
+++ b/toolsets/src/Windows.cpp
@@ -42,7 +42,7 @@ void WindowsToolset::CreateCommandsFor(Project &project)
         std::string includes;
         for(auto &d : getIncludePathsFor(component))
         {
-            includes += " /I" + d;
+            includes += " /I" + filesystem::relative(d).string();
         }
 
         // TODO: modules: -fmodules-ts --precompile  -fmodules-cache-path=<directory>-fprebuilt-module-path=<directory>
@@ -52,10 +52,10 @@ void WindowsToolset::CreateCommandsFor(Project &project)
         {
             if(!project.IsCompilationUnit(f->path.extension().string()))
                 continue;
-            filesystem::path temp = (f->path.string().substr(component.root.string().size() + 3) + ".obj");
+            filesystem::path temp = (f->path.string().substr(component.root.string().size()) + ".obj");
             filesystem::path outputFile = std::string("obj") / outputFolder / temp;
             File *of = project.CreateFile(component, outputFile);
-            PendingCommand *pc = new PendingCommand(compiler + " /c /EHsc " + Configuration::Get().compileFlags + " /Fo" + filesystem::weakly_canonical(outputFile).string() + " " + filesystem::weakly_canonical(f->path).string() + includes);
+            PendingCommand *pc = new PendingCommand(compiler + " /c /EHsc " + Configuration::Get().compileFlags + includes + " /Fo" + filesystem::weakly_canonical(outputFile).string() + " " + filesystem::weakly_canonical(f->path).string());
             objects.push_back(of);
             pc->AddOutput(of);
             std::unordered_set<File *> d;
@@ -93,7 +93,7 @@ void WindowsToolset::CreateCommandsFor(Project &project)
             else
             {
                 outputFile = "bin\\" + getExeNameFor(component);
-                command = linker + " /OUT:" + filesystem::weakly_canonical(outputFile).string();
+                command = linker + " /OUT:" + outputFile.string();
 
                 for(auto &file : objects)
                 {

--- a/toolsets/src/Windows.cpp
+++ b/toolsets/src/Windows.cpp
@@ -99,10 +99,7 @@ void WindowsToolset::CreateCommandsFor(Project &project)
                 {
                     command += " " + file->path.string();
                 }
-                if(filesystem::exists("lib"))
-                {
-                    command += " /LIBPATH:lib";
-                }
+                command += " /LIBPATH:lib";
                 std::vector<std::vector<Component *>> linkDeps = GetTransitiveAllDeps(component);
                 std::reverse(linkDeps.begin(), linkDeps.end());
                 for(auto d : linkDeps)

--- a/toolsets/src/Windows.cpp
+++ b/toolsets/src/Windows.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <stack>
 
-
 static const std::string compiler = "cl.exe";
 static const std::string linker = "link.exe";
 static const std::string archiver = "lib.exe";
@@ -32,7 +31,7 @@ static std::string getExeNameFor(Component &component)
     {
         return as_dotted(component.root.string()) + ".exe";
     }
-    return filesystem::canonical(component.root).filename().string() + ".exe";
+    return filesystem::weakly_canonical(component.root).filename().string() + ".exe";
 }
 
 void WindowsToolset::CreateCommandsFor(Project &project)
@@ -56,7 +55,7 @@ void WindowsToolset::CreateCommandsFor(Project &project)
             filesystem::path temp = (f->path.string().substr(component.root.string().size() + 3) + ".obj");
             filesystem::path outputFile = std::string("obj") / outputFolder / temp;
             File *of = project.CreateFile(component, outputFile);
-            PendingCommand *pc = new PendingCommand(compiler + " /c /EHsc " + Configuration::Get().compileFlags + " /Fo" + filesystem::weakly_canonical(outputFile).string() + " " + filesystem::canonical(f->path).string() + includes);
+            PendingCommand *pc = new PendingCommand(compiler + " /c /EHsc " + Configuration::Get().compileFlags + " /Fo" + filesystem::weakly_canonical(outputFile).string() + " " + filesystem::weakly_canonical(f->path).string() + includes);
             objects.push_back(of);
             pc->AddOutput(of);
             std::unordered_set<File *> d;
@@ -84,7 +83,7 @@ void WindowsToolset::CreateCommandsFor(Project &project)
             if(component.type == "library")
             {
                 outputFile = "lib\\" + getLibNameFor(component);
-                command = archiver + " " + filesystem::absolute(outputFile).string();
+                command = archiver + " " + filesystem::weakly_canonical(outputFile).string();
                 for(auto &file : objects)
                 {
                     command += " " + file->path.string();

--- a/toolsets/src/android.cpp
+++ b/toolsets/src/android.cpp
@@ -211,7 +211,10 @@ void AndroidToolset::CreateCommandsFor(Project &project)
                     {
                         command += " " + file->path.string();
                     }
-                    command += " -Llib";
+                    if(filesystem::exists("lib"))
+                    {
+                        command += " -Llib";
+                    }
                     std::vector<std::vector<Component *>> linkDeps = GetTransitiveAllDeps(component);
                     std::reverse(linkDeps.begin(), linkDeps.end());
                     for(auto d : linkDeps)

--- a/toolsets/src/ubuntu.cpp
+++ b/toolsets/src/ubuntu.cpp
@@ -90,7 +90,10 @@ void UbuntuToolset::CreateCommandsFor(Project &project)
                 {
                     command += " " + file->path.string();
                 }
-                command += " -Llib";
+                if(filesystem::exists("lib"))
+                {
+                    command += " -Llib";
+                }
                 std::vector<std::vector<Component *>> linkDeps = GetTransitiveAllDeps(component);
                 std::reverse(linkDeps.begin(), linkDeps.end());
                 for(auto d : linkDeps)

--- a/toolsets/src/ubuntu.cpp
+++ b/toolsets/src/ubuntu.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <stack>
 
+
 static const std::string compiler = "g++";
 static const std::string archiver = "ar";
 
@@ -90,10 +91,7 @@ void UbuntuToolset::CreateCommandsFor(Project &project)
                 {
                     command += " " + file->path.string();
                 }
-                if(filesystem::exists("lib"))
-                {
-                    command += " -Llib";
-                }
+                command += " -Llib";
                 std::vector<std::vector<Component *>> linkDeps = GetTransitiveAllDeps(component);
                 std::reverse(linkDeps.begin(), linkDeps.end());
                 for(auto d : linkDeps)


### PR DESCRIPTION
It should work now. Only tested it for small executables. Doesn't yet build evoke itself (could be an external dependency problem, namely can't find boost).
However, evoke on windows should be run via the "developer command prompt" application since that's where the build environment variables are stored in windows. Running from a simple command prompt or the powershell would throw a boost process error because it wouldn't find the compiler.