### PR TITLE
Support subcomponent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(
     FATAL_ERROR
@@ -57,8 +54,7 @@ find_package(Threads REQUIRED)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
    OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-       AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0")
-   OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+       AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0"))
   find_package(Boost REQUIRED COMPONENTS filesystem system)
   target_link_libraries(${PROJECT_NAME} PRIVATE Boost::disable_autolinking)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(
     FATAL_ERROR
@@ -54,7 +57,8 @@ find_package(Threads REQUIRED)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
    OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-       AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0"))
+       AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0")
+   OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
   find_package(Boost REQUIRED COMPONENTS filesystem system)
   target_link_libraries(${PROJECT_NAME} PRIVATE Boost::disable_autolinking)
 else()

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ bin/evoke: bin/evoke_make
 	bin/evoke_make
 	@echo Build complete. Please copy bin/evoke to wherever you want to install it.
 
-bin/evoke_make: $(patsubst %.cpp,o/%.o,$(shell find ./ -name *.cpp))
+bin/evoke_make: $(patsubst %.cpp,o/%.o,$(shell find . -name *.cpp -not -regex ".*/test/.*"))
 	@mkdir -p $(dir $@)
 	$(CXX) -O3 -std=c++17 -pthread -o $@ $^ -L$(BOOST_LIB_DIR) -lboost_filesystem -lboost_system -Wl,-rpath -Wl,$(BOOST_LIB_DIR)
 

--- a/fw/include/dotted.h
+++ b/fw/include/dotted.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include "fw/filesystem.hpp"
+
 #include <string>
 
 std::string as_dotted(std::string);
+
+filesystem::path removeDot(filesystem::path const &p);
+

--- a/fw/src/dotted.cpp
+++ b/fw/src/dotted.cpp
@@ -8,3 +8,12 @@ std::string as_dotted(std::string str)
     std::replace(str.begin(), str.end(), '/', '.');
     return str;
 }
+
+filesystem::path removeDot(filesystem::path const &p)
+{
+    if (p.begin()->filename_is_dot())
+    {
+        return relative(p, ".");
+    }
+    return p;
+}

--- a/fw/test/dotted.cpp
+++ b/fw/test/dotted.cpp
@@ -1,7 +1,7 @@
 #include "dotted.h"
 
 #include <algorithm>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 namespace btt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(remove_dot)

--- a/fw/test/dotted.cpp
+++ b/fw/test/dotted.cpp
@@ -1,0 +1,13 @@
+#include "dotted.h"
+
+#include <algorithm>
+#include <boost/test/included/unit_test.hpp>
+namespace btt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(remove_dot)
+{
+    using filesystem::path;
+    BOOST_TEST(removeDot("./folder/filename").generic_string() == "folder/filename");
+
+    BOOST_TEST(removeDot("folder/filename").generic_string() == "folder/filename");
+}

--- a/fw/test/main.cpp
+++ b/fw/test/main.cpp
@@ -1,0 +1,4 @@
+#define BOOST_TEST_MODULE Evoke.fw
+#include <boost/test/included/unit_test.hpp>
+
+// this is main for test

--- a/fw/test/main.cpp
+++ b/fw/test/main.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE Evoke.fw
+#define BOOST_TEST_MODULE Evoke_fw
 #include <boost/test/included/unit_test.hpp>
 
 // this is main for test

--- a/fw/test/path.cpp
+++ b/fw/test/path.cpp
@@ -1,0 +1,77 @@
+#include <algorithm>
+#include <boost/test/unit_test.hpp>
+namespace btt = boost::test_tools;
+
+#include "fw/filesystem.hpp"
+
+BOOST_AUTO_TEST_CASE(path_prefix)
+{
+    using filesystem::path;
+
+    path base{"./some_component/"};
+
+    BOOST_TEST(base.begin()->filename_is_dot());
+
+    BOOST_TEST(!path("some/sub/").begin()->filename_is_dot());
+}
+
+BOOST_AUTO_TEST_CASE(path_manipulate)
+{
+    using filesystem::path;
+
+    path base{"obj/"};
+
+    path file{base};
+    file /= "./file";
+
+    BOOST_TEST(file.string() == "obj/./file");
+    BOOST_TEST(file.lexically_normal().generic_string() == "obj/file");
+#if defined(_WIN32)
+    BOOST_TEST(file.lexically_normal().string() == "obj\\file");
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(path_base)
+{
+    using filesystem::path;
+    {
+        path base{"."};
+        path file{"./file"};
+
+        BOOST_TEST(file.lexically_relative(base).string() == "file");
+        BOOST_TEST(relative(file).string() == "file");
+
+        path fileRelated{"file"};
+        BOOST_TEST(fileRelated.lexically_relative(base).string() == "");
+
+        BOOST_TEST(relative(fileRelated).string() == "");
+    }
+
+    {
+        path base{"./component"};
+        path file{"./component/src/folder/file"};
+
+        BOOST_TEST(file.lexically_relative(base).generic_string() == "src/folder/file");
+        BOOST_TEST(file.lexically_relative(base / "src").generic_string() == "folder/file");
+    }
+
+    {
+        path base{"./component"};
+        path file{"./component/src/folder/file"};
+
+        BOOST_TEST(relative(file, base).generic_string() == "src/folder/file");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(path_append)
+{
+    using filesystem::path;
+
+    path base{"obj/"};
+    path file{base};
+    file += "./file.ext";
+    file += ".o";
+
+    BOOST_TEST(file.string() == "obj/./file.ext.o");
+    BOOST_TEST(file.lexically_normal().generic_string() == "obj/file.ext.o");
+}

--- a/project/include/Component.h
+++ b/project/include/Component.h
@@ -29,6 +29,7 @@ public:
     bool buildSuccess;
     bool isBinary;
     std::string accumulatedErrors;
+    std::string name;
 };
 
 std::ostream &operator<<(std::ostream &os, const Component &component);

--- a/project/test/main.cpp
+++ b/project/test/main.cpp
@@ -2,28 +2,9 @@
 #define BOOST_TEST_MODULE Evoke_project
 #include "Component.h"
 
-#include <boost/interprocess/file_mapping.hpp>
-#include <boost/interprocess/mapped_region.hpp>
-#include <boost/test/include/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 namespace btt = boost::test_tools;
-
-BOOST_AUTO_TEST_CASE(mmap_file)
-{
-    filesystem::path path{"project/test/main.cpp"};
-
-    using namespace boost::interprocess;
-    file_mapping file(path.string().c_str(), read_only);
-    mapped_region region(file, read_only);
-
-    //Get the address of the mapped region
-    void *addr = region.get_address();
-    std::size_t size = region.get_size();
-
-    size_t fileSize = filesystem::file_size(path);
-    BOOST_TEST(fileSize == size);
-    BOOST_TEST(strncmp(static_cast<char *>(addr), "// mmap", 7) == 0);
-}
 
 BOOST_AUTO_TEST_CASE(without_last_flash)
 {

--- a/project/test/main.cpp
+++ b/project/test/main.cpp
@@ -6,9 +6,16 @@
 
 namespace btt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE(without_last_flash)
+BOOST_AUTO_TEST_CASE(without_last_slash)
 {
     Component c("./my/component", true);
+
+    BOOST_TEST(c.name == "my_component");
+}
+
+BOOST_AUTO_TEST_CASE(with_last_slash)
+{
+    Component c("./my/component/", true);
 
     BOOST_TEST(c.name == "my_component");
 }

--- a/project/test/main.cpp
+++ b/project/test/main.cpp
@@ -1,0 +1,33 @@
+// mmap
+#define BOOST_TEST_MODULE Evoke_project
+#include "Component.h"
+
+#include <boost/interprocess/file_mapping.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <boost/test/include/unit_test.hpp>
+
+namespace btt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(mmap_file)
+{
+    filesystem::path path{"project/test/main.cpp"};
+
+    using namespace boost::interprocess;
+    file_mapping file(path.string().c_str(), read_only);
+    mapped_region region(file, read_only);
+
+    //Get the address of the mapped region
+    void *addr = region.get_address();
+    std::size_t size = region.get_size();
+
+    size_t fileSize = filesystem::file_size(path);
+    BOOST_TEST(fileSize == size);
+    BOOST_TEST(strncmp(static_cast<char *>(addr), "// mmap", 7) == 0);
+}
+
+BOOST_AUTO_TEST_CASE(without_last_flash)
+{
+    Component c("./my/component", true);
+
+    BOOST_TEST(c.name == "my_component");
+}

--- a/toolsets/src/Toolset.cpp
+++ b/toolsets/src/Toolset.cpp
@@ -9,11 +9,7 @@
 
 std::string Toolset::getNameFor(const Component &component)
 {
-    if(component.root.string() != ".")
-    {
-        return as_dotted(component.root.generic_string());
-    }
-    return filesystem::weakly_canonical(component.root).filename().string();
+    return component.GetName();
 }
 
 std::unique_ptr<Toolset> ParseToolset(const std::string &name);

--- a/toolsets/src/android.cpp
+++ b/toolsets/src/android.cpp
@@ -242,7 +242,7 @@ void AndroidToolset::CreateCommandsFor(Project &project)
                             continue;
                         if(d.size() == 1)
                         {
-                            command += " -l" + d[0]->root.string();
+                            command += " -l" + d[0]->GetName();
                         }
                         else
                         {
@@ -251,7 +251,7 @@ void AndroidToolset::CreateCommandsFor(Project &project)
                             {
                                 if(!c->isHeaderOnly())
                                 {
-                                    command += " -l" + c->root.string();
+                                    command += " -l" + c->GetName();
                                 }
                             }
                             command += " -Wl,--end-group";
@@ -294,7 +294,7 @@ void AndroidToolset::CreateCommandsFor(Project &project)
             }
 
             // Create apk from manifest & shared libraries
-            std::string outputName = component.root.filename().string();
+            std::string outputName = component.GetName();
             std::shared_ptr<PendingCommand> pc = std::make_shared<PendingCommand>(config.aapt(outputName, manifest));
             File *uapkfile = project.CreateFile(component, "apk/unsigned_" + outputName + ".apk");
             pc->AddOutput(uapkfile);

--- a/toolsets/src/clang.cpp
+++ b/toolsets/src/clang.cpp
@@ -61,7 +61,7 @@ std::string ClangToolset::getUnityCommand(const std::string &program, const std:
     {
         for(auto &c : d)
         {
-            command += " -l" + c->root.string();
+            command += " -l" + c->GetName();
         }
     }
     return command;
@@ -109,7 +109,7 @@ std::string ClangToolset::getLinkerCommand(const std::string &program, const std
     {
         for(auto &c : d)
         {
-            command += " -l" + c->root.string();
+            command += " -l" + c->GetName();
         }
     }
     return command;

--- a/toolsets/src/gcc.cpp
+++ b/toolsets/src/gcc.cpp
@@ -49,7 +49,11 @@ std::string GccToolset::getLibNameFor(const Component &component)
 
 std::string GccToolset::getExeNameFor(const Component &component)
 {
+#if defined(_WIN32)
+    return getNameFor(component) + ".exe";
+#else
     return getNameFor(component);
+#endif
 }
 
 std::string GccToolset::getUnityCommand(const std::string &program, const std::string &compileFlags, const std::string &outputFile, const File *inputFile, const std::set<std::string> &includes, std::vector<std::vector<Component *>> linkDeps)
@@ -68,7 +72,7 @@ std::string GccToolset::getUnityCommand(const std::string &program, const std::s
             command += " -Wl,--start-group";
             for(auto &c : d)
             {
-                command += " -l" + c->root.string();
+                command += " -l" + getNameFor(*c);
             }
             command += " -Wl,--end-group";
         }
@@ -121,14 +125,14 @@ std::string GccToolset::getLinkerCommand(const std::string &program, const std::
     {
         if(d.size() == 1)
         {
-            command += " -l" + d.front()->root.string();
+            command += " -l" + getNameFor(*d.front());
         }
         else
         {
             command += " -Wl,--start-group";
             for(auto &c : d)
             {
-                command += " -l" + c->root.string();
+                command += " -l" + getNameFor(*c);
             }
             command += " -Wl,--end-group";
         }

--- a/toolsets/src/msvc.cpp
+++ b/toolsets/src/msvc.cpp
@@ -60,7 +60,7 @@ std::string MsvcToolset::getUnityCommand(const std::string &program, const std::
     for(auto &d : linkDeps)
         for(auto &c : d)
         {
-            command += " -l" + c->root.string();
+            command += " -l" + c->GetName();
         }
     return command;
 }
@@ -102,7 +102,7 @@ std::string MsvcToolset::getLinkerCommand(const std::string &program, const std:
     for(auto &d : linkDeps)
         for(auto &c : d)
         {
-            command += " " + getLibNameFor(*c);
+            command += " -l" + c->GetName();
         }
     return command;
 }


### PR DESCRIPTION
This may be big. It includes serveral related issue.
* improved the code to remove prefix './' from component root path by using path::is_dot_filename()
* fixed sub-component name. for example, path 'module1/submodule1/src', it were make libaray in name libmodule1_submodule1.a in gcc style. 
* using a separated field 'name' for component name. this may be improved more.
* add unit test for above code. using boost.test library. those has not been included in cmake/Makefile yet. only evoke invoke those. yes!

Shall we leave android toolset code alone, since there is a separate branch to incubate it? It's unstructed and different from others.