### PR TITLE
optimized appveyor and cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 project(evoke)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -51,14 +51,15 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 if (MINGW)
   set(Boost_ARCHITECTURE -x64)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
-   OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-       AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0"))
+   OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0")
+   OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   find_package(Boost REQUIRED COMPONENTS filesystem system)
   target_link_libraries(${PROJECT_NAME} PRIVATE Boost::disable_autolinking)
 else()
@@ -70,6 +71,3 @@ target_include_directories(${PROJECT_NAME}
                            PRIVATE ${INCLUDES} ${Boost_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}
                       PRIVATE Threads::Threads ${Boost_LIBRARIES})
-if (MINGW)
-  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.9)
 project(evoke)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ set(SOURCES
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 
+if (MINGW)
+  set(Boost_ARCHITECTURE -x64)
+endif()
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
@@ -66,3 +70,6 @@ target_include_directories(${PROJECT_NAME}
                            PRIVATE ${INCLUDES} ${Boost_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}
                       PRIVATE Threads::Threads ${Boost_LIBRARIES})
+if (MINGW)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
+endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,23 @@ environment:
 build_script:
 - cmd: >-
     set MINGW=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64
+
     set PATH=%MINGW%\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+
     if not exist %MINGW%\bin\make.exe copy %MINGW%\bin\mingw32-make.exe %MINGW%\bin\make.exe
+
     cd %BOOSTROOT%
+
     if not exist b2.exe bootstrap
+
     b2 toolset=%TOOLSET% address-model=64 link=static variant=release --with-filesystem --with-system
+
     cd c:\projects\evoke
+
     cmake -E make_directory build
+
     cmake -E chdir build cmake %BUILD% ..
+
     cmake --build build --config Release
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,24 @@
 version: 1.0.{build}
-
-os: Visual Studio 2017
-
+image: Visual Studio 2017
 environment:
+  BOOSTROOT: C:\Libraries\boost_1_69_0
   matrix:
-  - MSVC_ARCH: x64
-    BOOST_ROOT: C:\Libraries\boost_1_67_0
-    BOOST_INCLUDEDIR: C:\Libraries\boost_1_67_0\boost
-    BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-15.0
-    CMAKE_GENERATOR: 'Visual Studio 15 2017'
-
-configuration: Release
-
+  - BUILD: -G "Visual Studio 15 2017" -A x64
+    TOOLSET: msvc-14.1
+  - BUILD: -G "MinGW Makefiles"
+    TOOLSET: gcc
 build_script:
-- set PATH=%BOOST_LIBRARYDIR%;%PATH%
-- cmake -E make_directory build
-- cmake -E chdir build cmake -G "%CMAKE_GENERATOR%" -A "%MSVC_ARCH%" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" ..
-- cmake --build build --config Release
+- cmd: >-
+    set MINGW=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64
+    set PATH=%MINGW%\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+    if not exist %MINGW%\bin\make.exe copy %MINGW%\bin\mingw32-make.exe %MINGW%\bin\make.exe
+    cd %BOOSTROOT%
+    if not exist b2.exe bootstrap
+    b2 toolset=%TOOLSET% address-model=64 link=static variant=release --with-filesystem --with-system
+    cd c:\projects\evoke
+    cmake -E make_directory build
+    cmake -E chdir build cmake %BUILD% ..
+    cmake --build build --config Release
 
 artifacts:
 - path: build/Release/evoke.exe
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,27 +7,24 @@ environment:
     TOOLSET: msvc-14.1
   - BUILD: -G "MinGW Makefiles"
     TOOLSET: gcc
+    PATH: C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+cache: C:\Libraries\boost_1_69_0\stage\lib
 build_script:
+# remove git/sh.exe to void cmake error
 - cmd: >-
-    set MINGW=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64
-
-    set PATH=%MINGW%\bin;%PATH:C:\Program Files\Git\usr\bin;=%
-
-    if not exist %MINGW%\bin\make.exe copy %MINGW%\bin\mingw32-make.exe %MINGW%\bin\make.exe
+    set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
 
     cd %BOOSTROOT%
 
-    if not exist b2.exe bootstrap
-
-    b2 toolset=%TOOLSET% address-model=64 link=static variant=release --with-filesystem --with-system
+    if not exist stage\lib\.build (mkdir stage\lib && bootstrap && b2 toolset=%TOOLSET% address-model=64 link=static variant=release --with-filesystem --with-system > stage\lib\.build)
 
     cd c:\projects\evoke
 
-    cmake -E make_directory build
-
-    cmake -E chdir build cmake %BUILD% ..
+    cmake -S . -B build %BUILD%
 
     cmake --build build --config Release
-
 artifacts:
 - path: build/Release/evoke.exe
+  name: evoke
+- path: build/evoke.exe
+  name: evoke

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 channels:
   - defaults
 dependencies:
-  - cmake>=3.13
+  - cmake>=3.9
   - libboost>=1.64

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 channels:
   - defaults
 dependencies:
-  - cmake>=3.8
+  - cmake>=3.13
   - libboost>=1.64


### PR DESCRIPTION
add mingw64 build
simplify the configuration of boost
  - rebuild static library for mingw64 and msvc.
  - use cache to avoid rebuild every time.
upgrade cmake to 3.13 for simple options: -S . -B build