### PR TITLE
Fix msvc link library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   )
 endif()
 
-add_subdirectory("toolsets/test")
+if(EVOKE_BUILD_WITH_UNITTEST)
+    add_subdirectory("toolsets/test")
+endif()
 
 set(INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}/evoke/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   )
 endif()
 
+add_subdirectory("toolsets/test")
+
 set(INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}/evoke/include
     ${CMAKE_CURRENT_SOURCE_DIR}/fw/include

--- a/toolsets/src/msvc.cpp
+++ b/toolsets/src/msvc.cpp
@@ -90,7 +90,7 @@ std::string MsvcToolset::getLinkerCommand(const std::string &program, const std:
     for(auto &d : linkDeps)
         for(auto &c : d)
         {
-            command += " -l" + c->GetName();
+            command += " " + getLibNameFor(*c);
         }
     return command;
 }

--- a/toolsets/test/CMakeLists.txt
+++ b/toolsets/test/CMakeLists.txt
@@ -43,6 +43,8 @@ set(LINKED_SOURCES
 set(SOURCES
     main.cpp
     msvc_test.cpp
+    clang_test.cpp
+    gcc_test.cpp
 )
 
 if(MSVC)

--- a/toolsets/test/CMakeLists.txt
+++ b/toolsets/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LINKED_SOURCES
     ../../project/src/File.cpp
     ../../fw/src/Configuration.cpp
     ../../fw/src/dotted.cpp
+    ../../fw/src/FileParser.cpp
     ../src/msvc.cpp
     ../src/known.cpp
     ../src/Toolset.cpp

--- a/toolsets/test/CMakeLists.txt
+++ b/toolsets/test/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.9)
+project(evoke_test_toolsets)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(
+    FATAL_ERROR
+    "Prevented in-tree build. Please create a build directory outside of the source directory and call cmake from there."
+  )
+endif()
+
+set(INCLUDES
+    ../../evoke/include
+    ../../fw/include
+    ../../project/include
+    ../../reporter/include
+    ../../toolsets/include
+    ../../utils/include
+    ../../view/include
+)
+
+set(LINKED_SOURCES
+    ../../project/src/PendingCommand.cpp
+    ../../project/src/PredefComponents.cpp
+    ../../project/src/ReadCode.cpp
+    ../../project/src/Project.cpp
+    ../../project/src/Component.cpp
+    ../../project/src/tarjan.cpp
+    ../../project/src/File.cpp
+    ../../fw/src/Configuration.cpp
+    ../../fw/src/dotted.cpp
+    ../src/msvc.cpp
+    ../src/known.cpp
+    ../src/Toolset.cpp
+    ../src/generic.cpp
+    ../src/clang.cpp
+    ../src/gcc.cpp
+    ../src/android.cpp
+ )
+
+set(SOURCES
+    main.cpp
+    msvc_test.cpp
+)
+
+if(MSVC)
+  source_group("Linked Source Files" FILES ${LINKED_SOURCES})
+endif(MSVC)
+
+add_executable(${PROJECT_NAME} ${SOURCES} ${LINKED_SOURCES})
+
+if (MINGW)
+  set(Boost_ARCHITECTURE -x64)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32)
+endif()
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+   OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0.0")
+   OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  find_package(Boost REQUIRED COMPONENTS filesystem system unit_test_framework)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Boost::disable_autolinking)
+else()
+  find_package(Boost REQUIRED COMPONENTS system unit_test_framework)
+  target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
+endif()
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${INCLUDES} ${Boost_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads ${Boost_LIBRARIES})
+
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${PROJECT_NAME} COMMENT "Running unit tests")

--- a/toolsets/test/clang_test.cpp
+++ b/toolsets/test/clang_test.cpp
@@ -1,0 +1,41 @@
+#include "dotted.h"
+#include "Component.h"
+#include "File.h"
+#include "Toolset.h"
+#include "Project.h"
+#include <algorithm>
+#include <set>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(clang_comile)
+{
+    Component c("hello", true);
+    Project p("./");
+    File *input = p.CreateFile(c, "hello/src/gretting.cpp");
+    const std::set<std::string> includes {"hello/include"};
+    ClangToolset clang;
+    auto cmd = clang.getCompileCommand("clang++", "-std=c++17", "obj/hello/src/gretting.cpp.obj", input, includes, false);
+    BOOST_TEST(cmd == "clang++ -c -std=c++17 -o obj/hello/src/gretting.cpp.obj hello/src/gretting.cpp -Ihello/include");
+}
+BOOST_AUTO_TEST_CASE(clang_archive)
+{
+    Component c("mylib", true);
+    Project p("./");
+    File *input = p.CreateFile(c, "obj/mylib/src/mylib.cpp.obj");
+    ClangToolset clang;
+    auto cmd = clang.getArchiverCommand("ar", "lib/libmylib.lib", {input});
+    BOOST_TEST(cmd == "ar rcs lib/libmylib.lib obj/mylib/src/mylib.cpp.obj");
+} 
+BOOST_AUTO_TEST_CASE(clang_link)
+{
+    Component c("mylib", true);
+    c.type = "library";
+    c.buildSuccess = true;
+    Project p("./");
+    File *input1 = p.CreateFile(c, "obj/hello/src/gretting.cpp.obj");
+    File *input2 = p.CreateFile(c, "obj/hello/src/main.cpp.obj");
+    ClangToolset clang;
+    auto cmd = clang.getLinkerCommand("clang++", "bin/hello.exe", {input1, input2}, {{&c}});
+    BOOST_TEST(cmd == "clang++ -pthread -o bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj -Llib -lmylib");
+}
+

--- a/toolsets/test/clang_test.cpp
+++ b/toolsets/test/clang_test.cpp
@@ -7,7 +7,7 @@
 #include <set>
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(clang_comile)
+BOOST_AUTO_TEST_CASE(clang_compile)
 {
     Component c("hello", true);
     Project p("./");
@@ -17,6 +17,7 @@ BOOST_AUTO_TEST_CASE(clang_comile)
     auto cmd = clang.getCompileCommand("clang++", "-std=c++17", "obj/hello/src/gretting.cpp.obj", input, includes, false);
     BOOST_TEST(cmd == "clang++ -c -std=c++17 -o obj/hello/src/gretting.cpp.obj hello/src/gretting.cpp -Ihello/include");
 }
+
 BOOST_AUTO_TEST_CASE(clang_archive)
 {
     Component c("mylib", true);
@@ -25,7 +26,8 @@ BOOST_AUTO_TEST_CASE(clang_archive)
     ClangToolset clang;
     auto cmd = clang.getArchiverCommand("ar", "lib/libmylib.lib", {input});
     BOOST_TEST(cmd == "ar rcs lib/libmylib.lib obj/mylib/src/mylib.cpp.obj");
-} 
+}
+
 BOOST_AUTO_TEST_CASE(clang_link)
 {
     Component c("mylib", true);
@@ -38,4 +40,3 @@ BOOST_AUTO_TEST_CASE(clang_link)
     auto cmd = clang.getLinkerCommand("clang++", "bin/hello.exe", {input1, input2}, {{&c}});
     BOOST_TEST(cmd == "clang++ -pthread -o bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj -Llib -lmylib");
 }
-

--- a/toolsets/test/gcc_test.cpp
+++ b/toolsets/test/gcc_test.cpp
@@ -1,0 +1,41 @@
+#include "dotted.h"
+#include "Component.h"
+#include "File.h"
+#include "Toolset.h"
+#include "Project.h"
+#include <algorithm>
+#include <set>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(gcc_comile)
+{
+    Component c("hello", true);
+    Project p("./");
+    File *input = p.CreateFile(c, "hello/src/gretting.cpp");
+    const std::set<std::string> includes {"hello/include"};
+    GccToolset gcc;
+    auto cmd = gcc.getCompileCommand("g++", "-std=c++17", "obj/hello/src/gretting.cpp.obj", input, includes, false);
+    BOOST_TEST(cmd == "g++ -c -std=c++17 -o obj/hello/src/gretting.cpp.obj hello/src/gretting.cpp -Ihello/include");
+}
+BOOST_AUTO_TEST_CASE(gcc_archive)
+{
+    Component c("mylib", true);
+    Project p("./");
+    File *input = p.CreateFile(c, "obj/mylib/src/mylib.cpp.obj");
+    GccToolset gcc;
+    auto cmd = gcc.getArchiverCommand("ar", "lib/libmylib.lib", {input});
+    BOOST_TEST(cmd == "ar rcs lib/libmylib.lib obj/mylib/src/mylib.cpp.obj");
+} 
+BOOST_AUTO_TEST_CASE(gcc_link)
+{
+    Component c("mylib", true);
+    c.type = "library";
+    c.buildSuccess = true;
+    Project p("./");
+    File *input1 = p.CreateFile(c, "obj/hello/src/gretting.cpp.obj");
+    File *input2 = p.CreateFile(c, "obj/hello/src/main.cpp.obj");
+    GccToolset gcc;
+    auto cmd = gcc.getLinkerCommand("g++", "bin/hello.exe", {input1, input2}, {{&c}});
+    BOOST_TEST(cmd == "g++ -pthread -o bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj -Llib -lmylib");
+}
+

--- a/toolsets/test/gcc_test.cpp
+++ b/toolsets/test/gcc_test.cpp
@@ -7,7 +7,7 @@
 #include <set>
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(gcc_comile)
+BOOST_AUTO_TEST_CASE(gcc_compile)
 {
     Component c("hello", true);
     Project p("./");
@@ -17,6 +17,7 @@ BOOST_AUTO_TEST_CASE(gcc_comile)
     auto cmd = gcc.getCompileCommand("g++", "-std=c++17", "obj/hello/src/gretting.cpp.obj", input, includes, false);
     BOOST_TEST(cmd == "g++ -c -std=c++17 -o obj/hello/src/gretting.cpp.obj hello/src/gretting.cpp -Ihello/include");
 }
+
 BOOST_AUTO_TEST_CASE(gcc_archive)
 {
     Component c("mylib", true);
@@ -25,7 +26,8 @@ BOOST_AUTO_TEST_CASE(gcc_archive)
     GccToolset gcc;
     auto cmd = gcc.getArchiverCommand("ar", "lib/libmylib.lib", {input});
     BOOST_TEST(cmd == "ar rcs lib/libmylib.lib obj/mylib/src/mylib.cpp.obj");
-} 
+}
+
 BOOST_AUTO_TEST_CASE(gcc_link)
 {
     Component c("mylib", true);
@@ -38,4 +40,3 @@ BOOST_AUTO_TEST_CASE(gcc_link)
     auto cmd = gcc.getLinkerCommand("g++", "bin/hello.exe", {input1, input2}, {{&c}});
     BOOST_TEST(cmd == "g++ -pthread -o bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj -Llib -lmylib");
 }
-

--- a/toolsets/test/main.cpp
+++ b/toolsets/test/main.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE Evoke_fw
+#define BOOST_TEST_MODULE Evoke_toolsets
 #include <boost/test/included/unit_test.hpp>
 
 // this is main for test

--- a/toolsets/test/main.cpp
+++ b/toolsets/test/main.cpp
@@ -1,0 +1,4 @@
+#define BOOST_TEST_MODULE Evoke_fw
+#include <boost/test/included/unit_test.hpp>
+
+// this is main for test

--- a/toolsets/test/msvc_test.cpp
+++ b/toolsets/test/msvc_test.cpp
@@ -1,21 +1,28 @@
-#include "dotted.h"
 #include "Component.h"
 #include "File.h"
-#include "Toolset.h"
 #include "Project.h"
-#include <algorithm>
-#include <set>
-#include <boost/test/unit_test.hpp>
+#include "Toolset.h"
+#include "dotted.h"
 
-BOOST_AUTO_TEST_CASE(msvc_comile)
+#include <algorithm>
+#include <boost/test/unit_test.hpp>
+#include <set>
+
+BOOST_AUTO_TEST_CASE(msvc_compile)
 {
     Component c("hello", true);
     Project p("./");
     File *input = p.CreateFile(c, "hello/src/gretting.cpp");
-    const std::set<std::string> includes {"hello\include"};
+    const std::set<std::string> includes{"hello\include"};
     MsvcToolset msvc;
     auto cmd = msvc.getCompileCommand("cl.exe", "/permissive- /std:c++latest", "obj/hello/src/gretting.cpp.obj", input, includes, false);
     BOOST_TEST(cmd == "cl.exe /c /EHsc /permissive- /std:c++latest /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp /Ihello\include");
+
+    cmd = msvc.getCompileCommand("cl.exe", "/permissive- /std:c++latest", "obj/hello/src/gretting.cpp.obj", input, {}, false);
+    BOOST_TEST(cmd == "cl.exe /c /EHsc /permissive- /std:c++latest /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp");
+
+    cmd = msvc.getCompileCommand("cl.exe", "", "obj/hello/src/gretting.cpp.obj", input, {}, false);
+    BOOST_TEST(cmd == "cl.exe /c /EHsc  /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp");
 }
 BOOST_AUTO_TEST_CASE(msvc_archive)
 {
@@ -29,13 +36,13 @@ BOOST_AUTO_TEST_CASE(msvc_archive)
 BOOST_AUTO_TEST_CASE(msvc_link)
 {
     Component c("mylib", true);
-    c.type = "library";
-    c.buildSuccess = true;
     Project p("./");
     File *input1 = p.CreateFile(c, "obj/hello/src/gretting.cpp.obj");
     File *input2 = p.CreateFile(c, "obj/hello/src/main.cpp.obj");
     MsvcToolset msvc;
-    auto cmd = msvc.getLinkerCommand("link.exe", "bin/hello.exe", {input1, input2}, {{&c}});
+    auto cmd = msvc.getLinkerCommand("link.exe", "bin/hello.exe", {input1, input2}, {{}});
+    BOOST_TEST(cmd == "link.exe /OUT:bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj /LIBPATH:lib");
+
+    cmd = msvc.getLinkerCommand("link.exe", "bin/hello.exe", {input1, input2}, {{&c}});
     BOOST_TEST(cmd == "link.exe /OUT:bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj /LIBPATH:lib libmylib.lib");
 }
-

--- a/toolsets/test/msvc_test.cpp
+++ b/toolsets/test/msvc_test.cpp
@@ -1,0 +1,41 @@
+#include "dotted.h"
+#include "Component.h"
+#include "File.h"
+#include "Toolset.h"
+#include "Project.h"
+#include <algorithm>
+#include <set>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(comile)
+{
+    Component c("hello", true);
+    Project p("./");
+    File *input = p.CreateFile(c, "hello/src/gretting.cpp");
+    const std::set<std::string> includes {"hello\include"};
+    MsvcToolset msvc;
+    auto cmd = msvc.getCompileCommand("cl.exe", "/permissive- /std:c++latest", "obj/hello/src/gretting.cpp.obj", input, includes, false);
+    BOOST_TEST(cmd == "cl.exe /c /EHsc /permissive- /std:c++latest /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp /Ihello\include");
+}
+BOOST_AUTO_TEST_CASE(archive)
+{
+    Component c("mylib", true);
+    Project p("./");
+    File *input = p.CreateFile(c, "obj/mylib/src/mylib.cpp.obj");
+    MsvcToolset msvc;
+    auto cmd = msvc.getArchiverCommand("lib.exe", "lib/libmylib.lib", {input});
+    BOOST_TEST(cmd == "lib.exe /OUT:lib/libmylib.lib obj/mylib/src/mylib.cpp.obj");
+} 
+BOOST_AUTO_TEST_CASE(link)
+{
+    Component c("mylib", true);
+    c.type = "library";
+    c.buildSuccess = true;
+    Project p("./");
+    File *input1 = p.CreateFile(c, "obj/hello/src/gretting.cpp.obj");
+    File *input2 = p.CreateFile(c, "obj/hello/src/main.cpp.obj");
+    MsvcToolset msvc;
+    auto cmd = msvc.getLinkerCommand("link.exe", "bin/hello.exe", {input1, input2}, {{&c}});
+    BOOST_TEST(cmd == "link.exe /OUT:bin/hello.exe obj/hello/src/gretting.cpp.obj obj/hello/src/main.cpp.obj /LIBPATH:lib libmylib.lib");
+}
+

--- a/toolsets/test/msvc_test.cpp
+++ b/toolsets/test/msvc_test.cpp
@@ -7,7 +7,7 @@
 #include <set>
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(comile)
+BOOST_AUTO_TEST_CASE(msvc_comile)
 {
     Component c("hello", true);
     Project p("./");
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(comile)
     auto cmd = msvc.getCompileCommand("cl.exe", "/permissive- /std:c++latest", "obj/hello/src/gretting.cpp.obj", input, includes, false);
     BOOST_TEST(cmd == "cl.exe /c /EHsc /permissive- /std:c++latest /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp /Ihello\include");
 }
-BOOST_AUTO_TEST_CASE(archive)
+BOOST_AUTO_TEST_CASE(msvc_archive)
 {
     Component c("mylib", true);
     Project p("./");
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(archive)
     auto cmd = msvc.getArchiverCommand("lib.exe", "lib/libmylib.lib", {input});
     BOOST_TEST(cmd == "lib.exe /OUT:lib/libmylib.lib obj/mylib/src/mylib.cpp.obj");
 } 
-BOOST_AUTO_TEST_CASE(link)
+BOOST_AUTO_TEST_CASE(msvc_link)
 {
     Component c("mylib", true);
     c.type = "library";


### PR DESCRIPTION
- Fixed msvc link command again.
- Added unit test for clang/gcc/msvc getNNNCommand methods to support future refactorings. Since Boost.Test is already used, I stick with it.
- Added the unit test project to CMakeLists. So that it will build and run with each build.
- I didn't touch the Unity command, since I m´not sure how it is supposed to work.
