### PR TITLE
Msvc module support

### DIFF
--- a/project/src/File.cpp
+++ b/project/src/File.cpp
@@ -28,7 +28,7 @@ bool File::isHeader(const fs::path &path)
 
 bool File::isTranslationUnit(const fs::path &path)
 {
-    static const std::unordered_set<std::string> exts = {".c", ".C", ".cc", ".cpp", ".cppm", ".m", ".mm", ".s", ".S"};
+    static const std::unordered_set<std::string> exts = {".c", ".C", ".cc", ".cpp", ".cppm", ".m", ".mm", ".s", ".S", "*.ixx"};
     return exts.find(path.extension().generic_string()) != exts.end();
 }
 

--- a/project/src/File.cpp
+++ b/project/src/File.cpp
@@ -22,13 +22,13 @@ void File::reloadHash() {
 
 bool File::isHeader(const fs::path &path)
 {
-    static const std::unordered_set<std::string> exts = {".h", ".H", ".hpp", ".hh", ".tcc", ".ipp", ".inc"};
+    static const std::unordered_set<std::string> exts = {".h", ".H", ".hpp", ".hh", ".tcc", ".ipp", ".inc", ".ixx"};
     return exts.find(path.extension().generic_string()) != exts.end();
 }
 
 bool File::isTranslationUnit(const fs::path &path)
 {
-    static const std::unordered_set<std::string> exts = {".c", ".C", ".cc", ".cpp", ".cppm", ".m", ".mm", ".s", ".S", "*.ixx"};
+    static const std::unordered_set<std::string> exts = {".c", ".C", ".cc", ".cpp", ".cppm", ".m", ".mm", ".s", ".S", ".ixx"};
     return exts.find(path.extension().generic_string()) != exts.end();
 }
 

--- a/project/src/Project.cpp
+++ b/project/src/Project.cpp
@@ -247,7 +247,7 @@ void Project::MapImportsToModules(std::unordered_map<std::string, File *> &modul
             }
             else
             {
-                std::cerr << "Could not find module " << import.first.c_str() << " imported by " << f.second->path.c_str() << '\n';
+                std::cerr << "Could not find module " << import.first << " imported by " << f.second->path << '\n';
             }
         }
     }

--- a/toolsets/src/msvc.cpp
+++ b/toolsets/src/msvc.cpp
@@ -8,10 +8,6 @@
 #include <algorithm>
 #include <stack>
 
-//https://blogs.msdn.microsoft.com/vcblog/2015/12/03/c-modules-in-vs-2015-update-1/
-// Enable modules support for MSVC
-//"/experimental:module /module:stdIfcDir \"$(VC_IFCPath)\" /module:search obj/modules/"
-
 MsvcToolset::MsvcToolset()
 {
     SetParameter("name", "msvc");
@@ -43,7 +39,7 @@ std::string MsvcToolset::getExeNameFor(const Component &component)
 
 std::string MsvcToolset::getUnityCommand(const std::string &program, const std::string &outputFile, const File *inputFile, const std::set<std::string> &includes, std::vector<std::vector<Component *>> linkDeps)
 {
-    std::string command = program + " /c /EHsc /Fo" + outputFile + " " + inputFile->path.generic_string();
+    std::string command = program + " /nologo /c /EHsc /Fo" + outputFile + " " + inputFile->path.generic_string();
     for(auto &i : includes)
         command += " /I" + i;
     for(auto &d : linkDeps)
@@ -56,7 +52,12 @@ std::string MsvcToolset::getUnityCommand(const std::string &program, const std::
 
 std::string MsvcToolset::getPrecompileCommand(const std::string &program, const std::string &outputFile, const File *inputFile, const std::set<std::string> &includes, bool hasModules)
 {
-    std::string command = program + " /c /EHsc /Fo" + outputFile + " " + inputFile->path.generic_string();
+    std::string command = program + " /nologo /c /EHsc";
+    if(hasModules)
+    {
+        command += " /experimental:module /std:c++20 /MD /permissive-";
+    }
+    command += " /Fo" + outputFile + " " + inputFile->path.generic_string();
     for(auto &i : includes)
         command += " /I" + i;
     return command;
@@ -64,7 +65,12 @@ std::string MsvcToolset::getPrecompileCommand(const std::string &program, const 
 
 std::string MsvcToolset::getCompileCommand(const std::string &program, const std::string &outputFile, const File *inputFile, const std::set<std::string> &includes, bool hasModules)
 {
-    std::string command = program + " /c /EHsc /Fo" + outputFile + " " + inputFile->path.generic_string();
+    std::string command = program + " /nologo /c /EHsc";
+    if(hasModules)
+    {
+        command += " /experimental:module /std:c++20 /MD /permissive-";
+    }
+    command += " /Fo" + outputFile + " " + inputFile->path.generic_string();
     for(auto &i : includes)
         command += " /I" + i;
     return command;

--- a/toolsets/test/msvc_test.cpp
+++ b/toolsets/test/msvc_test.cpp
@@ -16,10 +16,13 @@ BOOST_AUTO_TEST_CASE(msvc_compile)
     const std::set<std::string> includes{"hello\\include"};
     MsvcToolset msvc;
     auto cmd = msvc.getCompileCommand("cl.exe", "obj/hello/src/gretting.cpp.obj", input, includes, false);
-    BOOST_TEST(cmd == "cl.exe /c /EHsc /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp /Ihello\\include");
+    BOOST_TEST(cmd == "cl.exe /nologo /c /EHsc /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp /Ihello\\include");
 
     cmd = msvc.getCompileCommand("cl.exe", "obj/hello/src/gretting.cpp.obj", input, {}, false);
-    BOOST_TEST(cmd == "cl.exe /c /EHsc /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp");
+    BOOST_TEST(cmd == "cl.exe /nologo /c /EHsc /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp");
+
+    cmd = msvc.getCompileCommand("cl.exe", "obj/hello/src/gretting.cpp.obj", input, {}, true);
+    BOOST_TEST(cmd == "cl.exe /nologo /c /EHsc /experimental:module /std:c++20 /MD /permissive- /Foobj/hello/src/gretting.cpp.obj hello/src/gretting.cpp");
 }
 BOOST_AUTO_TEST_CASE(msvc_archive)
 {


### PR DESCRIPTION
- Fix `sha512` to use boost memory mapped file. That removes the conditional build.
- Add c++20 module feature for toolset msvc. Requires at least MSVC v142 16.2 toolset.
