### PR TITLE
clear another mess left by reporter

### DIFF
--- a/project/src/ReadCode.cpp
+++ b/project/src/ReadCode.cpp
@@ -4,6 +4,7 @@
 #include "known.h"
 
 #include <algorithm>
+#include <cstring>
 #include <fcntl.h>
 #include <fw/filesystem.hpp>
 

--- a/reporter/src/ConsoleReporter.cpp
+++ b/reporter/src/ConsoleReporter.cpp
@@ -115,10 +115,9 @@ void ConsoleReporter::ReportCommand(size_t , std::shared_ptr<PendingCommand> cmd
         // Display error
         if(cmd->result->errorcode)
         {
-            std::cout << "\n\n"
-                      << "Error while running: " << cmd->commandToRun;
-            std::cout << "\n\n"
-                      << cmd->result->output << "\n\n";
+            std::cerr << "Error while running: " << cmd->commandToRun
+                      << "\033[0K\n\033[0K"
+                      << cmd->result->output << "\033[0K\n\033[0K";
         }
     }
 }


### PR DESCRIPTION
Hey @dascandy
I hadn't noticed when I was looking at it the other day that the compile errors I was seeing were output by evoke. I thought it was the compiler being noisy and interrupting.

Therefore I've added the `\e[K` to the end of each of those lines as well. I removed a few newlines that looked to me like they'd been added as a hackish way of clearing the line (what `\e[K` does now). If you prefer the newlines present, just put them back ;)

Also, I took the liberty of changing the print device from `stdout` to `stderr` in alignment with the error message from `ReportUnknownHeaders`

Finally I added the `<cstring>` include. I hope you find it a harmless add in your build. Without it, it wouldn't build here

Hope you're enjoying the weekend, and thanks for poking me the other day. It was fun to troubleshoot it :)

Cheers!