### PR TITLE
Initialize boolean members.

### DIFF
--- a/project/include/Component.h
+++ b/project/include/Component.h
@@ -26,9 +26,9 @@ public:
     std::unordered_set<Component *> pubDeps, privDeps;
     std::unordered_set<std::string> pubIncl;
     std::string type;
-    bool buildSuccess;
-    bool isBinary;
-    bool isPredefComponent;
+    bool buildSuccess{false};
+    bool isBinary{false};
+    bool isPredefComponent{false};
     std::string accumulatedErrors;
     std::string name;
 };


### PR DESCRIPTION
Problem on Win64:
A project with a libary wasn't build, because the main was build before the library.
Reason:
On Win non initialized boolean (debug mode) are interpreted as true. The `isPredefComponent` of the library component was initialized to true and therefore the library wasn't build as a dependency of the executable.
